### PR TITLE
Add exception handling to sentiment analysis UDF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Thanks for helping us build KSQL functions! Simply fork this repo, make your changes, and submit a PR. Someone from [magicalpipelines][mp] will review your PR, merge your changes, and deploy the new or updated artifacts to Maven Central.
+
+[mp]: https://github.com/magicalpipelines
+
+## Maintainer note
+
+Assuming you've created your GPG key and can sign the artifacts, simply run the following to publish new versions of a UDF to Maven Central.
+
+```bash
+$ export GPG_TTY=$(tty)
+$ mvn clean deploy
+```

--- a/udf/sentiment-analysis/pom.xml
+++ b/udf/sentiment-analysis/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.mitchseymour</groupId>
     <artifactId>ksql-udf-sentiment-analysis</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>jar</packaging>
 
     <name>KSQL UDF for sentiment analysis</name>

--- a/udf/sentiment-analysis/src/main/java/com/mitchseymour/ksql/functions/SentimentUdf.java
+++ b/udf/sentiment-analysis/src/main/java/com/mitchseymour/ksql/functions/SentimentUdf.java
@@ -22,7 +22,7 @@ import io.confluent.ksql.function.udf.UdfParameter;;
 @UdfDescription(
     name = "sentiment",
     description = "Sentiment analysis of text",
-    version = "0.2.0",
+    version = "0.2.1",
     author = "Mitch Seymour"
 )
 public class SentimentUdf implements Configurable {
@@ -61,18 +61,25 @@ public class SentimentUdf implements Configurable {
     @UdfParameter(value = "text", description = "the text to analyze")
     final String text) {
     
-    final Document doc = Document.newBuilder()
-        .setContent(text)
-        .setType(Type.PLAIN_TEXT)
-        .build();
-
-    // Detects the sentiment of the text
-    final Sentiment sentiment = language.analyzeSentiment(doc).getDocumentSentiment();
-    
-    // Build the result object
     final Map<String, Double> result = new HashMap<>();
-    result.put("score", Double.valueOf(sentiment.getScore()));
-    result.put("magnitude", Double.valueOf(sentiment.getMagnitude()));
+    try {
+      final Document doc = Document.newBuilder()
+      .setContent(text)
+      .setType(Type.PLAIN_TEXT)
+      .build();
+
+      // Detects the sentiment of the text
+      final Sentiment sentiment = language.analyzeSentiment(doc).getDocumentSentiment();
+
+      // Build the result object
+      result.put("score", Double.valueOf(sentiment.getScore()));
+      result.put("magnitude", Double.valueOf(sentiment.getMagnitude()));
+      result.put("success", 1.0);
+    } catch (Exception e) {
+      result.put("score", 0.0);
+      result.put("magnitude", 0.0);
+      result.put("success", 0.0);
+    }
     return result;
   }
 }


### PR DESCRIPTION
The NLP API client may throw an exception during certain scenarios (e.g. if the language of the source text isn't supported), so we should catch this exception instead of letting it bubble up and potentially crash the KSQL server.