### PR TITLE
Address breaking change in KSQL to configurable UDFs (part 1 - sentiment)

### DIFF
--- a/udf/sentiment-analysis/pom.xml
+++ b/udf/sentiment-analysis/pom.xml
@@ -202,6 +202,12 @@
             <artifactId>ksql-udf</artifactId>
             <version>${ksql.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>2.3.0</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Third party -->
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/udf/sentiment-analysis/pom.xml
+++ b/udf/sentiment-analysis/pom.xml
@@ -214,6 +214,12 @@
             <artifactId>google-cloud-language</artifactId>
             <version>1.67.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.27</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/udf/sentiment-analysis/pom.xml
+++ b/udf/sentiment-analysis/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.mitchseymour</groupId>
     <artifactId>ksql-udf-sentiment-analysis</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>KSQL UDF for sentiment analysis</name>

--- a/udf/sentiment-analysis/src/main/java/com/mitchseymour/ksql/functions/SentimentUdf.java
+++ b/udf/sentiment-analysis/src/main/java/com/mitchseymour/ksql/functions/SentimentUdf.java
@@ -14,10 +14,10 @@ import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.cloud.language.v1.LanguageServiceSettings;
 import com.google.cloud.language.v1.Sentiment;
 
-import io.confluent.common.Configurable;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
-import io.confluent.ksql.function.udf.UdfParameter;;
+import io.confluent.ksql.function.udf.UdfParameter;
+import org.apache.kafka.common.Configurable;
 
 @UdfDescription(
     name = "sentiment",

--- a/udf/sentiment-analysis/src/main/java/com/mitchseymour/ksql/functions/SentimentUdf.java
+++ b/udf/sentiment-analysis/src/main/java/com/mitchseymour/ksql/functions/SentimentUdf.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 @UdfDescription(
     name = "sentiment",
     description = "Sentiment analysis of text",
-    version = "0.2.1",
+    version = "0.3.0",
     author = "Mitch Seymour"
 )
 public class SentimentUdf implements Configurable {


### PR DESCRIPTION
A major breaking change to configurable UDFs was introduced in KSQL 5.2.1 (see confluentinc/ksql#2653). Basically, the `Configurable` interface that KSQL required UDFs to implement was changed from:
```
io.confluent.common.Configurable
```
to
```
org.apache.kafka.common.Configurable
```
This makes configurable UDFs incompatible across minor KSQL versions :(

I'll open another PR to address the other UDFs.